### PR TITLE
bugfix/popup_inner_click_issue_#42104

### DIFF
--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { ConfigContext } from '../config-provider';
-import type { AbstractTooltipProps } from '../tooltip';
-import Tooltip from '../tooltip';
 import type { RenderFunction } from '../_util/getRenderPropValue';
 import { getRenderPropValue } from '../_util/getRenderPropValue';
 import { getTransitionName } from '../_util/motion';
+import { ConfigContext } from '../config-provider';
+import type { AbstractTooltipProps } from '../tooltip';
+import Tooltip from '../tooltip';
 import PurePanel from './PurePanel';
 // CSSINJS
 import useStyle from './style';
@@ -28,7 +28,12 @@ const Overlay: React.FC<OverlayProps> = ({ title, content, prefixCls }) => {
   return (
     <>
       {title && <div className={`${prefixCls}-title`}>{getRenderPropValue(title)}</div>}
-      <div className={`${prefixCls}-inner-content`}>{getRenderPropValue(content)}</div>
+      <div
+        onClick={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) => e.stopPropagation()}
+        className={`${prefixCls}-inner-content`}
+      >
+        {getRenderPropValue(content)}
+      </div>
     </>
   );
 };


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

(Popup closed when clicking on icon inside the content)[https://github.com/ant-design/ant-design/issues/42104]

### 💡 Background and solution
## Issue:
When the popup is open and you click on an icon inside the content the popup close.

## Solution
By adding stopPropagation to the inner div the popup now function like it should.

### 📝 Changelog

bugfix: 
when clicking in inner content of the popup the popup was closing
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      X     |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
